### PR TITLE
remove unused internal function _setOwnersExplicit

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -420,29 +420,6 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
         emit Approval(owner, to, tokenId);
     }
 
-    uint256 public nextOwnerToExplicitlySet = 0;
-
-    /**
-     * @dev Explicitly set `owners` to eliminate loops in future calls of ownerOf().
-     */
-    function _setOwnersExplicit(uint256 quantity) internal {
-        uint256 oldNextOwnerToSet = nextOwnerToExplicitlySet;
-        require(quantity > 0, "quantity must be nonzero");
-        uint256 endIndex = oldNextOwnerToSet + quantity - 1;
-        if (endIndex > currentIndex - 1) {
-            endIndex = currentIndex - 1;
-        }
-        // We know if the last one in the group exists, all in the group exist, due to serial ordering.
-        require(_exists(endIndex), "not enough minted yet for this cleanup");
-        for (uint256 i = oldNextOwnerToSet; i <= endIndex; i++) {
-            if (_ownerships[i].addr == address(0)) {
-                TokenOwnership memory ownership = ownershipOf(i);
-                _ownerships[i] = TokenOwnership(ownership.addr, ownership.startTimestamp);
-            }
-        }
-        nextOwnerToExplicitlySet = endIndex + 1;
-    }
-
     /**
      * @dev Internal function to invoke {IERC721Receiver-onERC721Received} on a target address.
      * The call is not executed if the target address is not a contract.


### PR DESCRIPTION
This function and the associated public variable weren't used in this contract, the referenced OpenZeppelin contracts, or the MetaAngels contract. As far as I can tell, the `chiru-labs` team had some future plan for this function that have not yet come to fruition - https://github.com/chiru-labs/ERC721A/blob/main/README.md?plain=1#L59

...now that I think about this more though, I don't believe this function would be compiled into the main Meta Angels contract since it's not referenced. Not positive on that variable though. I would hope not, but don't know for certain. 